### PR TITLE
Add visionOS support and contentMargins-based scroll modifiers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),
+    .visionOS(.v1),
   ],
   products: [
     .library(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(

--- a/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
+++ b/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
@@ -51,6 +51,9 @@ public struct WithLayoutMargins<Content>: View where Content: View {
 @available(
   watchOS, deprecated: 9999.0, message: "Use the `.fitToReadableContentWidth` modifier instead."
 )
+@available(
+  visionOS, deprecated: 9999.0, message: "Use the `.fitToReadableContentWidth` modifier instead."
+)
 public struct FitReadableContentWidth<Content>: View where Content: View {
   let alignment: Alignment
   let content: Content
@@ -87,6 +90,9 @@ public struct FitReadableContentWidth<Content>: View where Content: View {
 )
 @available(
   watchOS, deprecated: 9999.0, message: "Use the `.fitToLayoutMarginsWidth` modifier instead."
+)
+@available(
+  visionOS, deprecated: 9999.0, message: "Use the `.fitToLayoutMarginsWidth` modifier instead."
 )
 public struct FitLayoutMarginsWidth<Content>: View where Content: View {
   let alignment: Alignment
@@ -215,7 +221,7 @@ struct LayoutGuidesModifier: ViewModifier {
 
   func body(content: Content) -> some View {
     content
-    #if os(iOS) || os(tvOS)
+    #if canImport(UIKit)
       .environment(\.layoutMarginsInsets, layoutMarginsInsets)
       .environment(\.readableContentInsets, readableContentInsets)
       .background(
@@ -231,7 +237,7 @@ struct LayoutGuidesModifier: ViewModifier {
   }
 }
 
-#if os(iOS) || os(tvOS)
+#if canImport(UIKit)
   import UIKit
   struct LayoutGuides: UIViewRepresentable {
     let onLayoutMarginsGuideChange: (EdgeInsets) -> Void
@@ -376,7 +382,7 @@ struct LayoutGuidesModifier: ViewModifier {
           VStack(spacing: 0) {
             sample("ScrollView") { ScrollViewTest() }
             sample("List.plain") { ListTest().listStyle(.plain) }
-            #if os(iOS) || os(tvOS)
+            #if canImport(UIKit)
               sample("List.grouped") { ListTest().listStyle(.grouped) }
               sample("List.insetGrouped") { ListTest().listStyle(.insetGrouped) }
             #endif
@@ -385,7 +391,7 @@ struct LayoutGuidesModifier: ViewModifier {
           VStack(spacing: 0) {
             sample("ScrollView") { ScrollViewTest() }
             sample("List.plain") { ListTest().listStyle(.plain) }
-            #if os(iOS) || os(tvOS)
+            #if canImport(UIKit)
               sample("List.grouped") { ListTest().listStyle(.grouped) }
               sample("List.insetGrouped") { ListTest().listStyle(.insetGrouped) }
             #endif

--- a/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
+++ b/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
@@ -166,9 +166,9 @@ internal struct ScrollContentFitLayoutGuidesWidth: ViewModifier {
     case layoutMargins
     case readableContent
   }
-  
+
   let kind: Kind
-  
+
   func body(content: Content) -> some View {
     switch kind {
     case .layoutMargins:
@@ -179,7 +179,7 @@ internal struct ScrollContentFitLayoutGuidesWidth: ViewModifier {
         .measureLayoutMargins()
     }
   }
-  
+
   private struct InsetReadableContent: ViewModifier {
     @Environment(\.readableContentInsets) var readableContentInsets
     func body(content: Content) -> some View {
@@ -188,7 +188,7 @@ internal struct ScrollContentFitLayoutGuidesWidth: ViewModifier {
         .contentMargins(.trailing, readableContentInsets.trailing, for: .scrollContent)
     }
   }
-  
+
   private struct InsetLayoutMargins: ViewModifier {
     @Environment(\.layoutMarginsInsets) var layoutMarginsInsets
     func body(content: Content) -> some View {
@@ -221,35 +221,29 @@ extension View {
   public func fitToLayoutMarginsWidth(alignment: Alignment = .center) -> some View {
     self.modifier(FitLayoutGuidesWidth(alignment: alignment, kind: .layoutMargins))
   }
-  
-  /// Use this modifier to make scroll view content fit the readable content width.
-  ///
-  /// This modifier uses the modern `contentMargins(_:for:)` API on iOS 17+ and other
-  /// supported platforms, which is the recommended approach for scroll views.
-  /// On older platforms, it falls back to the frame-based approach.
+
+  /// Use this modifier to make scroll view content fit the readable content width using
+  /// the `contentMargins(_:for:)` API.
   ///
   /// - Note: Prefer this modifier over ``fitToReadableContentWidth(alignment:)`` when
-  /// working with scroll views like `ScrollView`, `List`, or `TextEditor`.
+  /// working with scroll views or `List` views.
   /// - Note: You don't have to wrap this view inside a ``WithLayoutMargins`` view.
   @available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
   public func scrollContentFitToReadableContentWidth() -> some View {
     self.modifier(ScrollContentFitLayoutGuidesWidth(kind: .readableContent))
   }
-  
-  /// Use this modifier to make scroll view content fit the layout margins guide width.
-  ///
-  /// This modifier uses the modern `contentMargins(_:for:)` API on iOS 17+ and other
-  /// supported platforms, which is the recommended approach for scroll views.
-  /// On older platforms, it falls back to the frame-based approach.
+
+  /// Use this modifier to make scroll view content fit the layout margins guide width using
+  /// the `contentMargins(_:for:)` API.
   ///
   /// - Note: Prefer this modifier over ``fitToLayoutMarginsWidth(alignment:)`` when
-  /// working with scroll views like `ScrollView`, `List`, or `TextEditor`.
+  /// working with scroll views or `List` views.
   /// - Note: You don't have to wrap this view inside a ``WithLayoutMargins`` view.
   @available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
   public func scrollContentFitToLayoutMarginsWidth() -> some View {
     self.modifier(ScrollContentFitLayoutGuidesWidth(kind: .layoutMargins))
   }
-  
+
   /// Use this modifier to populate the ``layoutMarginsInsets`` and ``readableContentInsets``
   /// for the target view.
   ///

--- a/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
+++ b/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
@@ -160,6 +160,45 @@ internal struct FitLayoutGuidesWidth: ViewModifier {
   }
 }
 
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
+internal struct ScrollContentFitLayoutGuidesWidth: ViewModifier {
+  enum Kind {
+    case layoutMargins
+    case readableContent
+  }
+  
+  let kind: Kind
+  
+  func body(content: Content) -> some View {
+    switch kind {
+    case .layoutMargins:
+      content.modifier(InsetLayoutMargins())
+        .measureLayoutMargins()
+    case .readableContent:
+      content.modifier(InsetReadableContent())
+        .measureLayoutMargins()
+    }
+  }
+  
+  private struct InsetReadableContent: ViewModifier {
+    @Environment(\.readableContentInsets) var readableContentInsets
+    func body(content: Content) -> some View {
+      content
+        .contentMargins(.leading, readableContentInsets.leading, for: .scrollContent)
+        .contentMargins(.trailing, readableContentInsets.trailing, for: .scrollContent)
+    }
+  }
+  
+  private struct InsetLayoutMargins: ViewModifier {
+    @Environment(\.layoutMarginsInsets) var layoutMarginsInsets
+    func body(content: Content) -> some View {
+      content
+        .contentMargins(.leading, layoutMarginsInsets.leading, for: .scrollContent)
+        .contentMargins(.trailing, layoutMarginsInsets.trailing, for: .scrollContent)
+    }
+  }
+}
+
 extension View {
   /// Use this modifier to make the view fit the readable content width.
   ///
@@ -182,6 +221,35 @@ extension View {
   public func fitToLayoutMarginsWidth(alignment: Alignment = .center) -> some View {
     self.modifier(FitLayoutGuidesWidth(alignment: alignment, kind: .layoutMargins))
   }
+  
+  /// Use this modifier to make scroll view content fit the readable content width.
+  ///
+  /// This modifier uses the modern `contentMargins(_:for:)` API on iOS 17+ and other
+  /// supported platforms, which is the recommended approach for scroll views.
+  /// On older platforms, it falls back to the frame-based approach.
+  ///
+  /// - Note: Prefer this modifier over ``fitToReadableContentWidth(alignment:)`` when
+  /// working with scroll views like `ScrollView`, `List`, or `TextEditor`.
+  /// - Note: You don't have to wrap this view inside a ``WithLayoutMargins`` view.
+  @available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
+  public func scrollContentFitToReadableContentWidth() -> some View {
+    self.modifier(ScrollContentFitLayoutGuidesWidth(kind: .readableContent))
+  }
+  
+  /// Use this modifier to make scroll view content fit the layout margins guide width.
+  ///
+  /// This modifier uses the modern `contentMargins(_:for:)` API on iOS 17+ and other
+  /// supported platforms, which is the recommended approach for scroll views.
+  /// On older platforms, it falls back to the frame-based approach.
+  ///
+  /// - Note: Prefer this modifier over ``fitToLayoutMarginsWidth(alignment:)`` when
+  /// working with scroll views like `ScrollView`, `List`, or `TextEditor`.
+  /// - Note: You don't have to wrap this view inside a ``WithLayoutMargins`` view.
+  @available(iOS 17.0, macOS 14.0, tvOS 17.0, visionOS 1.0, watchOS 10.0, *)
+  public func scrollContentFitToLayoutMarginsWidth() -> some View {
+    self.modifier(ScrollContentFitLayoutGuidesWidth(kind: .layoutMargins))
+  }
+  
   /// Use this modifier to populate the ``layoutMarginsInsets`` and ``readableContentInsets``
   /// for the target view.
   ///

--- a/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
+++ b/Sources/SwiftUILayoutGuides/SwiftUILayoutGuides.swift
@@ -170,31 +170,23 @@ internal struct ScrollContentFitLayoutGuidesWidth: ViewModifier {
   let kind: Kind
 
   func body(content: Content) -> some View {
-    switch kind {
-    case .layoutMargins:
-      content.modifier(InsetLayoutMargins())
-        .measureLayoutMargins()
-    case .readableContent:
-      content.modifier(InsetReadableContent())
-        .measureLayoutMargins()
-    }
+    content.modifier(InsetContent(kind: kind))
+      .measureLayoutMargins()
   }
 
-  private struct InsetReadableContent: ViewModifier {
-    @Environment(\.readableContentInsets) var readableContentInsets
-    func body(content: Content) -> some View {
-      content
-        .contentMargins(.leading, readableContentInsets.leading, for: .scrollContent)
-        .contentMargins(.trailing, readableContentInsets.trailing, for: .scrollContent)
-    }
-  }
-
-  private struct InsetLayoutMargins: ViewModifier {
+  private struct InsetContent: ViewModifier {
+    let kind: Kind
     @Environment(\.layoutMarginsInsets) var layoutMarginsInsets
+    @Environment(\.readableContentInsets) var readableContentInsets
+
+    private var insets: EdgeInsets {
+      kind == .readableContent ? readableContentInsets : layoutMarginsInsets
+    }
+
     func body(content: Content) -> some View {
       content
-        .contentMargins(.leading, layoutMarginsInsets.leading, for: .scrollContent)
-        .contentMargins(.trailing, layoutMarginsInsets.trailing, for: .scrollContent)
+        .contentMargins(.leading, insets.leading, for: .scrollContent)
+        .contentMargins(.trailing, insets.trailing, for: .scrollContent)
     }
   }
 }


### PR DESCRIPTION
This fixes my two open issues:

**#8**: Updates platform checks to use `#if canImport(UIKit)` instead of hardcoded OS checks (`#if os(iOS) || os(tvOS)`). This covers visionOS and future-proofs things if a new platform comes out.

**#9**: Adds new scroll view modifiers that use the modern `contentMargins(_:for:)` API:
- `scrollContentFitToReadableContentWidth()`
- `scrollContentFitToLayoutMarginsWidth()`